### PR TITLE
elasticsearch index is always named `titan` regardless of name of index ...

### DIFF
--- a/src/main/java/org/lab41/web/controller/viz/ElasticSearchController.java
+++ b/src/main/java/org/lab41/web/controller/viz/ElasticSearchController.java
@@ -107,9 +107,7 @@ public class ElasticSearchController {
         StringBuilder stringBuilderElasticSearchURL = new StringBuilder();
         stringBuilderElasticSearchURL.append("http://");
         stringBuilderElasticSearchURL.append(elasticSearchHost);
-        stringBuilderElasticSearchURL.append(":9200/");
-        stringBuilderElasticSearchURL.append(indexName);
-        stringBuilderElasticSearchURL.append("/_search");
+        stringBuilderElasticSearchURL.append(":9200/titan/_search");
         String elasticSearchURL = stringBuilderElasticSearchURL.toString();
 
         // decode url-encoded json response back into json


### PR DESCRIPTION
...set in rexster's titan config
