### PR TITLE
explicitly use bash

### DIFF
--- a/bin/dendrite-server
+++ b/bin/dendrite-server
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2013 In-Q-Tel/Lab41
 #


### PR DESCRIPTION
on Ubuntu `/bin/sh` is a symlink to dash, not bash.

`(( ... ))` is a bash-ism, not recognized by dash.
