### PR TITLE
External graphs

### DIFF
--- a/bin/dendrite
+++ b/bin/dendrite
@@ -9,7 +9,6 @@ import sys
 import time
 from contextlib import closing
 
-
 # ----------------------------------------------------------------------------
 
 class Connection(object):
@@ -376,8 +375,12 @@ def run_groovy(args):
         graph = Graph.get(conn, args.id)
 
         print 'Running the groovy script...'
-        graph.run_groovy(args.script)
-        print 'done'
+        response = graph.run_groovy(args.script)
+
+        if args.pretty:
+            print json.dumps(response, indent=2)
+        else:
+            print json.dumps(response)
 
     return 0
 
@@ -520,6 +523,10 @@ def main():
 
     # Options for running jobs.
     parser_run_groovy = subparsers.add_parser('run-groovy')
+    parser_run_groovy.add_argument('--pretty',
+            default=False,
+            action='store_true',
+            help='Prettify the json response')
     parser_run_groovy.add_argument('id',
             type=not_empty,
             help='the id of the graph according to rexster')

--- a/data/init-graph-of-the-gods.groovy
+++ b/data/init-graph-of-the-gods.groovy
@@ -34,10 +34,10 @@ Vertex sea = g.addVertex(null);
 ElementHelper.setProperties(sea, "name", "sea", "type", "location", "vertexId", sea.getId().toString());
 
 Vertex jupiter = g.addVertex(null);
-ElementHelper.setProperties(jupiter, "name", "jupiter", "age", 5000, "type", "god", "_vertexId", jupiter.getId().toString());
+ElementHelper.setProperties(jupiter, "name", "jupiter", "age", 5000, "type", "god", "vertexId", jupiter.getId().toString());
 
 Vertex neptune = g.addVertex(null);
-ElementHelper.setProperties(neptune, "name", "neptune", "age", 4500, "type", "god", "_vertexId", neptune.getId().toString());
+ElementHelper.setProperties(neptune, "name", "neptune", "age", 4500, "type", "god", "vertexId", neptune.getId().toString());
 
 Vertex hercules = g.addVertex(null);
 ElementHelper.setProperties(hercules, "name", "hercules", "age", 30, "type", "demigod", "vertexId", hercules.getId().toString());

--- a/src/main/java/org/lab41/dendrite/graph/DendriteGraph.java
+++ b/src/main/java/org/lab41/dendrite/graph/DendriteGraph.java
@@ -44,7 +44,7 @@ public class DendriteGraph implements TitanGraph {
         return systemGraph;
     }
 
-    public TitanGraph getTitanGraph() {
+    synchronized public TitanGraph getTitanGraph() {
         if (titanGraph == null) {
             logger.debug("opening titan graph '" + id + "'");
 

--- a/src/main/java/org/lab41/dendrite/graph/DendriteGraphFactory.java
+++ b/src/main/java/org/lab41/dendrite/graph/DendriteGraphFactory.java
@@ -106,15 +106,18 @@ public class DendriteGraphFactory {
         return graph;
     }
 
-    public DendriteGraph openGraph(String id) {
-        return openGraph(id, false);
+    public DendriteGraph openGraph(String id, Configuration config) {
+        return openGraph(id, config, false);
     }
 
-    public DendriteGraph openGraph(String id, boolean systemGraph) {
+    public DendriteGraph openGraph(String id, Configuration config, boolean systemGraph) {
         DendriteGraph graph = graphs.get(id);
         if (graph == null) {
-            Configuration configuration = getConfiguration(id);
-            graph = new DendriteGraph(id, configuration, systemGraph);
+            if (config == null) {
+                config = getConfiguration(id);
+            }
+
+            graph = new DendriteGraph(id, config, systemGraph);
 
             graphs.put(id, graph);
         }

--- a/src/main/java/org/lab41/dendrite/models/GraphMetadata.java
+++ b/src/main/java/org/lab41/dendrite/models/GraphMetadata.java
@@ -1,42 +1,28 @@
 package org.lab41.dendrite.models;
 
 import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Property;
+import com.tinkerpop.frames.modules.javahandler.JavaHandler;
+import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
+
+import java.util.Properties;
 
 @TypeValue("graph")
-public interface GraphMetadata extends NamedMetadata {
+public interface GraphMetadata extends Metadata {
 
-    @Property("backend")
-    public String getBackend();
+    @Property("properties")
+    public Properties getProperties();
 
-    @Property("backend")
-    public void setBackend(String backent);
+    @Property("properties")
+    public void setProperties(Properties properties);
 
-    @Property("directory")
-    public String getDirectory();
-
-    @Property("directory")
-    public void setDirectory(String directory);
-
-    @Property("hostname")
-    public String getHostname();
-
-    @Property("hostname")
-    public void setHostname(String hostname);
-
-    @Property("port")
-    public Integer getPort();
-
-    @Property("port")
-    public void setPort(Integer port);
-
-    @Property("tablename")
-    public String getTablename();
-
-    @Property("tablename")
-    public void setTablename(String tablename);
+    @JavaHandler
+    public Configuration getConfiguration();
 
     @Adjacency(label = "project", direction = Direction.OUT)
     public ProjectMetadata getProject();
@@ -44,12 +30,17 @@ public interface GraphMetadata extends NamedMetadata {
     @Adjacency(label = "project", direction = Direction.OUT)
     public void setProject(ProjectMetadata projectMetadata);
 
-    /*
     public abstract class Impl implements JavaHandlerContext<Vertex>, GraphMetadata {
 
-        @Initializer
-        public void init() {
+        @Override
+        @JavaHandler
+        public Configuration getConfiguration() {
+            Properties properties = getProperties();
+            if (properties == null) {
+                return null;
+            } else {
+                return new MapConfiguration(properties);
+            }
         }
     }
-    */
 }

--- a/src/main/java/org/lab41/dendrite/services/MetadataService.java
+++ b/src/main/java/org/lab41/dendrite/services/MetadataService.java
@@ -6,6 +6,7 @@ import com.tinkerpop.frames.FramedGraphFactory;
 import com.tinkerpop.frames.modules.gremlingroovy.GremlinGroovyModule;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerModule;
 import com.tinkerpop.frames.modules.typedgraph.TypedGraphModuleBuilder;
+import org.apache.commons.configuration.Configuration;
 import org.lab41.dendrite.graph.DendriteGraph;
 import org.lab41.dendrite.graph.DendriteGraphFactory;
 import org.lab41.dendrite.models.*;
@@ -13,6 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Properties;
 
 @Service
 public class MetadataService {
@@ -30,7 +33,7 @@ public class MetadataService {
         this.dendriteGraphFactory = dendriteGraphFactory;
 
         // Get or create the metadata graph.
-        this.metadataGraph = dendriteGraphFactory.openGraph(METADATA_GRAPH_NAME, true);
+        this.metadataGraph = dendriteGraphFactory.openGraph(METADATA_GRAPH_NAME, null, true);
 
         // Create a FramedGraphFactory, which we'll use to wrap our metadata graph vertices and edges.
         this.metadataFrameFactory = new FramedGraphFactory(
@@ -89,37 +92,9 @@ public class MetadataService {
         }
 
         // GraphMetadata keys
-        if (metadataGraph.getType("backend") == null) {
-            metadataGraph.makeKey("backend")
-                    .dataType(String.class)
-                    .indexed(Vertex.class)
-                    .make();
-        }
-
-        if (metadataGraph.getType("directory") == null) {
-            metadataGraph.makeKey("directory")
-                    .dataType(String.class)
-                    .indexed(Vertex.class)
-                    .make();
-        }
-
-        if (metadataGraph.getType("hostname") == null) {
-            metadataGraph.makeKey("hostname")
-                    .dataType(String.class)
-                    .indexed(Vertex.class)
-                    .make();
-        }
-
-        if (metadataGraph.getType("port") == null) {
-            metadataGraph.makeKey("port")
-                    .dataType(Integer.class)
-                    .indexed(Vertex.class)
-                    .make();
-        }
-
-        if (metadataGraph.getType("tablename") == null) {
-            metadataGraph.makeKey("tablename")
-                    .dataType(String.class)
+        if (metadataGraph.getType("properties") == null) {
+            metadataGraph.makeKey("properties")
+                    .dataType(Properties.class)
                     .indexed(Vertex.class)
                     .make();
         }
@@ -161,7 +136,7 @@ public class MetadataService {
         MetadataTx tx = newTransaction();
 
         for(GraphMetadata graphMetadata: tx.getGraphs()) {
-            dendriteGraphFactory.openGraph(graphMetadata.getId());
+            dendriteGraphFactory.openGraph(graphMetadata.getId(), graphMetadata.getConfiguration());
         }
 
         tx.commit();
@@ -175,7 +150,7 @@ public class MetadataService {
             MetadataTx tx = newTransaction();
             GraphMetadata graphMetadata = tx.getGraph(id);
             if (graphMetadata != null) {
-                graph = dendriteGraphFactory.openGraph(id);
+                graph = dendriteGraphFactory.openGraph(id, graphMetadata.getConfiguration());
             }
 
             tx.commit();

--- a/src/main/java/org/lab41/dendrite/web/beans/CreateGraphBean.java
+++ b/src/main/java/org/lab41/dendrite/web/beans/CreateGraphBean.java
@@ -1,0 +1,15 @@
+package org.lab41.dendrite.web.beans;
+
+import java.util.Properties;
+
+public class CreateGraphBean {
+    private Properties properties;
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+}


### PR DESCRIPTION
This PR adds support for external graphs. To create one, do:

```
curl \
  -XPOST \
  -H 'content-type: application/json' \
  /api/projects/<project-id>/graphs \
  -d '{
    "properties":{
      "storage.backend":"local",
      "storage.directory": "/tmp/foo"
    }
  }'
```

It also does some minor cleanup, like fixing a race on opening graphs, corrects a typo in our example graph creation script, and finally allows `dendrite run-groovy` to print out the result of the script.
