### PR TITLE
Add ability to parse Faunus GraphSON format

### DIFF
--- a/src/main/java/org/lab41/dendrite/metagraph/DendriteGraphTx.java
+++ b/src/main/java/org/lab41/dendrite/metagraph/DendriteGraphTx.java
@@ -17,6 +17,7 @@ public class DendriteGraphTx extends TitanBlueprintsTransaction {
 
     private Lock tableLock;
     private TitanTransaction tx;
+    private final String searchIndexId = "vertexId";
 
     public DendriteGraphTx(Lock tableLock, TitanTransaction tx) {
         this.tableLock = tableLock;
@@ -25,12 +26,16 @@ public class DendriteGraphTx extends TitanBlueprintsTransaction {
 
     @Override
     public TitanVertex addVertex() {
-        return tx.addVertex();
+        TitanVertex vertex = tx.addVertex();
+        vertex.setProperty(searchIndexId, vertex.getId());
+        return vertex;
     }
 
     @Override
     public TitanVertex addVertex(Long id) {
-        return tx.addVertex(id);
+        TitanVertex vertex = tx.addVertex(id);
+        vertex.setProperty(searchIndexId, vertex.getId());
+        return vertex;
     }
 
     @Override
@@ -160,7 +165,9 @@ public class DendriteGraphTx extends TitanBlueprintsTransaction {
 
     @Override
     public TitanVertex addVertex(Object id) {
-        return (TitanVertex) tx.addVertex(id);
+        TitanVertex vertex = (TitanVertex) tx.addVertex(id);
+        vertex.setProperty(searchIndexId, vertex.getId());
+        return vertex;
     }
 
     @Override

--- a/src/main/java/org/lab41/dendrite/util/io/faunusgraphson/FaunusGraphSONReader.java
+++ b/src/main/java/org/lab41/dendrite/util/io/faunusgraphson/FaunusGraphSONReader.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2014
+  In-Q-Tel/Lab41
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lab41.dendrite.util.io.faunusgraphson;
+
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.util.wrappers.batch.BatchGraph;
+
+import com.thinkaurelius.faunus.FaunusVertex;
+import com.thinkaurelius.faunus.FaunusEdge;
+import com.thinkaurelius.faunus.formats.graphson.FaunusGraphSONUtility;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * FaunusGraphSONReader reads the data from a Faunus GraphSON stream to a graph.
+ */
+public class FaunusGraphSONReader {
+    private final Graph graph;
+
+    /**
+     * @param graph the graph to populate with the JSON data
+     */
+    public FaunusGraphSONReader(final Graph graph) {
+        this.graph = graph;
+    }
+
+    /**
+     * Input the JSON stream data into the graph.
+     * In practice, usually the provided graph is empty.
+     *
+     * @param inputStream an InputStream of JSON data
+     * @throws IOException thrown when the JSON data is not correctly formatted
+     */
+    public void inputGraph(final InputStream inputStream) throws IOException {
+        FaunusGraphSONReader.inputGraph(this.graph, inputStream, 1000);
+    }
+
+    /**
+     * Input the JSON stream data into the graph.
+     * In practice, usually the provided graph is empty.
+     *
+     * @param inputStream an InputStream of JSON data
+     * @param graph       the graph to populate with the JSON data
+     * @throws IOException thrown when the JSON data is not correctly formatted
+     */
+    public static void inputGraph(final Graph inputGraph, final InputStream inputStream) throws IOException {
+        FaunusGraphSONReader.inputGraph(inputGraph, inputStream, 1000);
+    }
+
+
+    /**
+     * Input the JSON stream data into the graph.
+     * In practice, usually the provided graph is empty.
+     *
+     * @param inputStream an InputStream of JSON data
+     * @param graph       the graph to populate with the JSON data
+     * @param bufferSize  the amount of elements to hold in memory before committing a transactions (only valid for TransactionalGraphs)
+     * @throws IOException thrown when the JSON data is not correctly formatted
+     */
+    public static void inputGraph(final Graph inputGraph, final InputStream inputStream, int bufferSize) throws IOException {
+      // titan requires creation of vertices before edges
+      // unless enabling the option to set vertex id upon creation,
+      // use a map to store the idFaunus->idBlueprints transformation
+      FaunusEdge fe;
+      Vertex vertexIn, vertexOut;
+      long faunusIdIn, faunusIdOut, blueprintsIdIn, blueprintsIdOut;
+      HashMap<Long, Long> faunusToBlueprintsId = new HashMap<Long, Long>();
+
+      // if this is a transactional graph then we're buffering
+      final BatchGraph graph = BatchGraph.wrap(inputGraph, bufferSize);
+
+      // load list of vertices
+      List<FaunusVertex> faunusVertexList = new FaunusGraphSONUtility().fromJSON(inputStream);
+
+      // add vertices w/ properties to graph, also saving id->id mapping for edge creation
+      Vertex blueprintsVertex;
+      for (FaunusVertex faunusVertex : faunusVertexList) {
+        blueprintsVertex = graph.addVertex(faunusVertex.getIdAsLong());
+        for (String property : faunusVertex.getPropertyKeys()) {
+          blueprintsVertex.setProperty(property, faunusVertex.getProperty(property));
+        }
+        faunusToBlueprintsId.put(faunusVertex.getIdAsLong(), (Long) blueprintsVertex.getId());
+      }
+
+      // add edges between vertices
+      for (FaunusVertex faunusVertex : faunusVertexList) {
+        for (Edge edge : faunusVertex.getEdges(Direction.BOTH)) {
+            fe = (FaunusEdge) edge;
+
+            // retrieve the vertices stored in the graph
+            faunusIdIn = fe.getVertexId(Direction.IN);
+            blueprintsIdIn = faunusToBlueprintsId.get(faunusIdIn);
+            faunusIdOut = fe.getVertexId(Direction.OUT);
+            blueprintsIdOut = faunusToBlueprintsId.get(faunusIdOut);
+            vertexIn = graph.getVertex(blueprintsIdIn);
+            vertexOut = graph.getVertex(blueprintsIdOut);
+
+            // save the edge to the graph
+            graph.addEdge(null, vertexIn, vertexOut, fe.getLabel());
+        }
+      }
+
+      // commit changes to the graph
+      graph.commit();
+    }
+
+}

--- a/src/main/webapp/js/app.js
+++ b/src/main/webapp/js/app.js
@@ -143,10 +143,15 @@ angular.module('dendrite', [
     },
     // **disclaimer: UI file parsing an experimental demo feature until server-side
     //    functionality complete.  UI parsing relies on client-side file import, as well as
-    //    wildcard regex and brute force array iteration.  Disable if importing large graph
-    //    files and/or if concerned about client browser performance
+    //    wildcard regex and brute force array iteration.  UI parsing also uses a custom
+    //    word separator (which could confuse JSON responses if keeping formatted values)
+    //    to compensate for GML using space-separated key-value pairs
+    //
+    //    Disable if importing large graph files and/or if concerned about client browser
+    //    performance
     fileUpload: {
       parseGraphFile: true,
+      parseSeparator: ":::",
       maxBytesLocal: Math.pow(1024,2)
     }
   }).

--- a/src/main/webapp/js/controllers.js
+++ b/src/main/webapp/js/controllers.js
@@ -105,10 +105,7 @@ angular.module('dendrite.controllers', []).
                 .$then(function(response) {
                     $scope.project = response.data.project;
                     $scope.graphId = $scope.project.current_graph;
-                    $scope.graph = Graph.get({graphId: $scope.graphId})
-                          .$then(function(res) {
-                            console.log(res);
-                          });
+                    $scope.graph = Graph.get({graphId: $scope.graphId});
 
                     $scope.forceDirectedGraphData = GraphTransform.reloadRandomGraph($scope.graphId);
                     $scope.$on('event:reloadGraph', function() {
@@ -238,7 +235,9 @@ angular.module('dendrite.controllers', []).
         var pollActive = function() {
               Graph.get({graphId: $routeParams.graphId})
                     .$then(function(dataGraph) {
-                        $scope.activeAnalytics = Project.jobs({projectId: dataGraph.data.graph.projectId});
+                        if (dataGraph.data.graph !== undefined) {
+                          $scope.activeAnalytics = Project.jobs({projectId: dataGraph.data.graph.projectId});
+                        }
                     });
               $timeout(pollActive, appConfig.analytics.metadata.pollTimeout);
         }
@@ -868,7 +867,9 @@ angular.module('dendrite.controllers', []).
           if (newVal !== undefined) {
               Histogram.searchFacets($scope.graphId)
                   .success(function(data) {
-                      $scope.searchFacets = Object.keys(data.vertex.properties);
+                      if (data.vertex !== undefined && data.vertex.properties !== undefined) {
+                        $scope.searchFacets = Object.keys(data.vertex.properties);
+                      }
                   });
 
               $scope.visualize = function() {

--- a/src/main/webapp/js/controllers.js
+++ b/src/main/webapp/js/controllers.js
@@ -820,6 +820,11 @@ angular.module('dendrite.controllers', []).
           }
         };
 
+        $scope.checkboxHasKey = function(key) {
+          var idx = $scope.selectedCheckboxes.indexOf(key);
+          return (idx > -1);
+        };
+
         $scope.$on('event:graphFileParsed', function() {
           if (!appConfig.fileUpload.parseGraphFile) {
             $scope.safeApply(function() {
@@ -831,6 +836,9 @@ angular.module('dendrite.controllers', []).
             if ($scope.keysForGraph.length > 0) {
               $scope.fileParsed = true;
               $scope.fileParseError = false;
+              Array().forEach.call($scope.keysForGraph, function(k) {
+                $scope.checkboxTally(k);
+              });
               $scope.safeApply(function() {
                 $modal({scope: $scope, template: 'partials/graphs/form-select-keys.html'});
               });

--- a/src/main/webapp/js/services.js
+++ b/src/main/webapp/js/services.js
@@ -122,7 +122,7 @@ angular.module('dendrite.services', ['ngResource']).
         user: currentUser
       };
     }).
-    factory('Helpers', function($resource) {
+    factory('Helpers', function($resource, appConfig) {
         //TODO: delete once backend APIs complete - dummy result array
         var analyticResults = [];
 
@@ -171,7 +171,6 @@ angular.module('dendrite.services', ['ngResource']).
                 else if (format === "GML") {
 
                   // parse via regex
-                  var regex_sep = ":::";
                   var regex_nodes = /node \[(.*?)\]/g
                   var regex_graph = /\[([.\s\S]*)\]/m
                   var regex_quote = /\".*?\"/g
@@ -195,7 +194,7 @@ angular.module('dendrite.services', ['ngResource']).
                     var firstIndex, condensed, properties_string_formatted = "";
                     while (quoted = regex_quote.exec(properties_string)) {
                       firstIndex = regex_quote.lastIndex - quoted[0].length;
-                      condensed = quoted[0].replace(/ /g, regex_sep);
+                      condensed = quoted[0].replace(/ /g, appConfig.fileUpload.parseSeparator);
                       properties_string_formatted += properties_string.substring(0,firstIndex) + condensed;
                     }
 

--- a/src/main/webapp/partials/graph-detail.html
+++ b/src/main/webapp/partials/graph-detail.html
@@ -41,6 +41,7 @@
               <option value="GraphSON">GraphSON</option>
               <option value="GraphML">GraphML</option>
               <option value="GML">GML</option>
+              <option value="FaunusGraphSON">Faunus GraphSON</option>
           </select>
 
           <div class="inline fileupload fileupload-new" data-provides="fileupload">

--- a/src/main/webapp/partials/graphs/form-select-keys.html
+++ b/src/main/webapp/partials/graphs/form-select-keys.html
@@ -7,11 +7,12 @@
 
   <div class="modal-body">
     <div class="well">
-      <p>Choose which fields, if any, should be indexed for search.</p>
+      <p><strong>Choose which fields, if any, should be indexed for search.</strong></p>
+      <p>**Note: the default "select all" option will make every field searchable, but at the expense of storing all data in two locations, namely the database and search engine.</p>
     </div>
 
     <label class="checkbox" ng-repeat="key in keysForGraph">
-      <input type="checkbox" ng-click="checkboxTally(key)" value="graph-key-{{keysForGraph.indexOf(key)}}"> {{ key }}
+      <input type="checkbox" ng-checked="checkboxHasKey(key)" ng-click="checkboxTally(key)" value="graph-key-{{keysForGraph.indexOf(key)}}"> {{ key }}
     </label>
   </div>
 

--- a/src/main/webapp/partials/project-detail.html
+++ b/src/main/webapp/partials/project-detail.html
@@ -23,6 +23,7 @@
                   <option value="GraphSON">GraphSON</option>
                   <option value="GraphML">GraphML</option>
                   <option value="GML">GML</option>
+                  <option value="FaunusGraphSON">Faunus GraphSON</option>
               </select>
 
               <div class="inline fileupload fileupload-new" data-provides="fileupload">

--- a/src/test/javascript/data/gods.faunusGraphSON
+++ b/src/test/javascript/data/gods.faunusGraphSON
@@ -1,0 +1,12 @@
+{"name":"saturn","type":"titan","_id":0,"_inE":[{"_label":"father","_id":12,"_outV":1}]}
+{"name":"jupiter","type":"god","_id":1,"_outE":[{"_label":"lives","_id":13,"_inV":4},{"_label":"brother","_id":16,"_inV":3},{"_label":"brother","_id":14,"_inV":2},{"_label":"father","_id":12,"_inV":0}],"_inE":[{"_label":"brother","_id":17,"_outV":3},{"_label":"brother","_id":15,"_outV":2},{"_label":"father","_id":24,"_outV":7}]}
+{"name":"neptune","type":"god","_id":2,"_outE":[{"_label":"lives","_id":20,"_inV":5},{"_label":"brother","_id":19,"_inV":3},{"_label":"brother","_id":15,"_inV":1}],"_inE":[{"_label":"brother","_id":18,"_outV":3},{"_label":"brother","_id":14,"_outV":1}]}
+{"name":"pluto","type":"god","_id":3,"_outE":[{"_label":"pet","_id":23,"_inV":11},{"_label":"lives","_id":21,"_inV":6},{"_label":"brother","_id":17,"_inV":1},{"_label":"brother","_id":18,"_inV":2}],"_inE":[{"_label":"brother","_id":19,"_outV":2},{"_label":"brother","_id":16,"_outV":1}]}
+{"name":"sky","type":"location","_id":4,"_inE":[{"_label":"lives","_id":13,"_outV":1}]}
+{"name":"sea","type":"location","_id":5,"_inE":[{"_label":"lives","_id":20,"_outV":2}]}
+{"name":"tartarus","type":"location","_id":6,"_inE":[{"_label":"lives","_id":21,"_outV":3},{"_label":"lives","_id":22,"_outV":11}]}
+{"name":"hercules","type":"demigod","_id":7,"_outE":[{"_label":"mother","_id":25,"_inV":8},{"time":1,"_label":"battled","_id":26,"_inV":9},{"time":2,"_label":"battled","_id":27,"_inV":10},{"time":12,"_label":"battled","_id":28,"_inV":11},{"_label":"father","_id":24,"_inV":1}]}
+{"name":"alcmene","type":"human","_id":8,"_inE":[{"_label":"mother","_id":25,"_outV":7}]}
+{"name":"nemean","type":"monster","_id":9,"_inE":[{"time":1,"_label":"battled","_id":26,"_outV":7}]}
+{"name":"hydra","type":"monster","_id":10,"_inE":[{"time":2,"_label":"battled","_id":27,"_outV":7}]}
+{"name":"cerberus","type":"monster","_id":11,"_outE":[{"_label":"lives","_id":22,"_inV":6}],"_inE":[{"_label":"pet","_id":23,"_outV":3},{"time":12,"_label":"battled","_id":28,"_outV":7}]}


### PR DESCRIPTION
- used FaunusGraphSONUtility to import faunus version of graphson 
- auto-index "vertexId" for frontend when adding vertices
- minor js cleanup for easier demo

TODO:
refactor elasticsearch indexname/indexfield ("vertexId" and "search") into config file (requires knowledge of java dark magic...probably in mordor)
