### PR TITLE
Simplify jung analysis services and fix a performance bug

### DIFF
--- a/src/main/java/org/lab41/dendrite/jobs/AbstractGraphUpdateJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/AbstractGraphUpdateJob.java
@@ -1,0 +1,76 @@
+package org.lab41.dendrite.jobs;
+
+import com.thinkaurelius.titan.core.TitanTransaction;
+import com.thinkaurelius.titan.core.attribute.FullDouble;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.oupls.jung.GraphJung;
+import com.tinkerpop.blueprints.util.wrappers.batch.BatchGraph;
+import org.lab41.dendrite.jobs.AbstractJob;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.DendriteGraphBatchWrapper;
+import org.lab41.dendrite.metagraph.DendriteGraphTx;
+import org.lab41.dendrite.metagraph.MetaGraph;
+import org.lab41.dendrite.metagraph.models.JobMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractGraphUpdateJob extends AbstractJob {
+
+    static Logger logger = LoggerFactory.getLogger(AbstractGraphUpdateJob.class);
+
+    protected DendriteGraph graph;
+
+    public AbstractGraphUpdateJob(MetaGraph metaGraph, String jobId, DendriteGraph graph) {
+        super(metaGraph, jobId);
+
+        this.graph = graph;
+    }
+
+    public void run() {
+        logger.debug("Starting " + getClass().getSimpleName() + " analysis on "
+                + graph.getId()
+                + " job " + jobId
+                + " " + Thread.currentThread().getName());
+
+        setJobName(jobId, getClass().getSimpleName());
+        setJobState(jobId, JobMetadata.RUNNING);
+
+        try {
+            try {
+                createIndices();
+                graph.commit();
+            } catch (Throwable t) {
+                graph.rollback();
+                throw t;
+            }
+
+            try {
+                updateGraph();
+                graph.commit();
+            } catch (Throwable t) {
+                graph.rollback();
+                throw t;
+            }
+
+            setJobState(jobId, JobMetadata.DONE);
+        } catch (Throwable t) {
+            setJobState(jobId, JobMetadata.ERROR, t.getMessage());
+            throw t;
+        }
+
+        logger.debug("Finished analysis on " + jobId);
+    }
+
+    protected abstract void updateGraph();
+
+    protected void createIndices() { }
+
+    protected void createVertexIndex(String key, Class cls) {
+        if (graph.getType(key) == null) {
+            graph.makeKey(key)
+                    .dataType(cls)
+                    .indexed(DendriteGraph.INDEX_NAME, Vertex.class)
+                    .make();
+        }
+    }
+}

--- a/src/main/java/org/lab41/dendrite/jobs/AbstractJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/AbstractJob.java
@@ -12,8 +12,8 @@ public abstract class AbstractJob {
 
     static Logger logger = LoggerFactory.getLogger(AbstractJob.class);
 
-    MetaGraph metaGraph;
-    String jobId;
+    protected MetaGraph metaGraph;
+    protected String jobId;
 
     public AbstractJob(MetaGraph metaGraph, String jobId) {
         this.metaGraph = metaGraph;

--- a/src/main/java/org/lab41/dendrite/jobs/jung/BarycenterDistanceJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/jung/BarycenterDistanceJob.java
@@ -1,0 +1,35 @@
+package org.lab41.dendrite.jobs.jung;
+
+import com.thinkaurelius.titan.core.attribute.FullDouble;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.oupls.jung.GraphJung;
+import edu.uci.ics.jung.algorithms.scoring.BarycenterScorer;
+import org.lab41.dendrite.jobs.AbstractGraphUpdateJob;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.MetaGraph;
+
+public class BarycenterDistanceJob extends AbstractGraphUpdateJob {
+
+    private static String BARYCENTER_KEY = "jungBarycenter";
+
+    public BarycenterDistanceJob(MetaGraph metaGraph, String jobId, DendriteGraph graph) {
+        super(metaGraph, jobId, graph);
+    }
+
+    @Override
+    protected void updateGraph() {
+        GraphJung<DendriteGraph> jungGraph = new GraphJung<>(graph);
+        BarycenterScorer<Vertex, Edge> barycenterScorer = new BarycenterScorer<>(jungGraph);
+
+        for (Vertex vertex: jungGraph.getVertices()) {
+            Double score = barycenterScorer.getVertexScore(vertex);
+            vertex.setProperty(BARYCENTER_KEY, score);
+        }
+    }
+
+    @Override
+    protected void createIndices() {
+        createVertexIndex(BARYCENTER_KEY, FullDouble.class);
+    }
+}

--- a/src/main/java/org/lab41/dendrite/jobs/jung/BetweennessCentralityJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/jung/BetweennessCentralityJob.java
@@ -1,0 +1,45 @@
+package org.lab41.dendrite.jobs.jung;
+
+import com.thinkaurelius.titan.core.attribute.FullDouble;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.oupls.jung.GraphJung;
+import edu.uci.ics.jung.algorithms.importance.BetweennessCentrality;
+import org.lab41.dendrite.jobs.AbstractGraphUpdateJob;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.MetaGraph;
+
+public class BetweennessCentralityJob extends AbstractGraphUpdateJob {
+
+    private static String BETWEENNESS_KEY = "jungBetweenness";
+
+    public BetweennessCentralityJob(MetaGraph metaGraph, String jobId, DendriteGraph graph) {
+        super(metaGraph, jobId, graph);
+    }
+
+    @Override
+    protected void updateGraph() {
+        GraphJung<DendriteGraph> jungGraph = new GraphJung<>(graph);
+        BetweennessCentrality<Vertex, Edge> betweennessCentrality = new BetweennessCentrality<>(jungGraph);
+
+        // Instructs the ranker that it should not remove the rank scores from
+        //  the nodes (or edges) once the ranks have been computed.
+        betweennessCentrality.setRemoveRankScoresOnFinalize(false);
+
+        // Performs the iterative process. Note: this method does not return
+        // anything because Java does not allow mixing double, int, or objects
+        // TODO: change this to step() so that insight into the process can be
+        // exposed
+        betweennessCentrality.evaluate();
+
+        for (Vertex vertex: graph.getVertices()) {
+            Double score = betweennessCentrality.getVertexRankScore(vertex);
+            vertex.setProperty(BETWEENNESS_KEY, score);
+        }
+    }
+
+    @Override
+    protected void createIndices() {
+        createVertexIndex(BETWEENNESS_KEY, FullDouble.class);
+    }
+}

--- a/src/main/java/org/lab41/dendrite/jobs/jung/ClosenessCentralityJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/jung/ClosenessCentralityJob.java
@@ -1,0 +1,35 @@
+package org.lab41.dendrite.jobs.jung;
+
+import com.thinkaurelius.titan.core.attribute.FullDouble;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.oupls.jung.GraphJung;
+import edu.uci.ics.jung.algorithms.scoring.ClosenessCentrality;
+import org.lab41.dendrite.jobs.AbstractGraphUpdateJob;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.MetaGraph;
+
+public class ClosenessCentralityJob extends AbstractGraphUpdateJob {
+
+    private static String CLOSENESS_KEY = "jungCloseness";
+
+    public ClosenessCentralityJob(MetaGraph metaGraph, String jobId, DendriteGraph graph) {
+        super(metaGraph, jobId, graph);
+    }
+
+    @Override
+    protected void updateGraph() {
+        GraphJung<DendriteGraph> jungGraph = new GraphJung<>(graph);
+        ClosenessCentrality<Vertex, Edge> closenessCentrality = new ClosenessCentrality<>(jungGraph);
+
+        for (Vertex vertex: graph.getVertices()) {
+            Double score = closenessCentrality.getVertexScore(vertex);
+            vertex.setProperty(CLOSENESS_KEY, score);
+        }
+    }
+
+    @Override
+    protected void createIndices() {
+        createVertexIndex(CLOSENESS_KEY, FullDouble.class);
+    }
+}

--- a/src/main/java/org/lab41/dendrite/jobs/jung/EigenvectorCentralityJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/jung/EigenvectorCentralityJob.java
@@ -1,0 +1,37 @@
+package org.lab41.dendrite.jobs.jung;
+
+import com.thinkaurelius.titan.core.attribute.FullDouble;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.oupls.jung.GraphJung;
+import edu.uci.ics.jung.algorithms.scoring.EigenvectorCentrality;
+import org.lab41.dendrite.jobs.AbstractGraphUpdateJob;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.MetaGraph;
+
+public class EigenvectorCentralityJob extends AbstractGraphUpdateJob {
+
+    private static String EIGENVECTOR_KEY = "jungEigenvector";
+
+    public EigenvectorCentralityJob(MetaGraph metaGraph, String jobId, DendriteGraph graph) {
+        super(metaGraph, jobId, graph);
+    }
+
+    @Override
+    protected void updateGraph() {
+        GraphJung<DendriteGraph> jungGraph = new GraphJung<>(graph);
+        EigenvectorCentrality<Vertex, Edge> eigenvectorCentrality = new EigenvectorCentrality<>(jungGraph);
+        eigenvectorCentrality.acceptDisconnectedGraph(true);
+        eigenvectorCentrality.evaluate();
+
+        for (Vertex vertex: graph.getVertices()) {
+            Double score = eigenvectorCentrality.getVertexScore(vertex);
+            vertex.setProperty(EIGENVECTOR_KEY, score);
+        }
+    }
+
+    @Override
+    protected void createIndices() {
+        createVertexIndex(EIGENVECTOR_KEY, FullDouble.class);
+    }
+}

--- a/src/main/java/org/lab41/dendrite/jobs/jung/PageRankJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/jung/PageRankJob.java
@@ -1,0 +1,39 @@
+package org.lab41.dendrite.jobs.jung;
+
+import com.thinkaurelius.titan.core.attribute.FullDouble;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.oupls.jung.GraphJung;
+import edu.uci.ics.jung.algorithms.scoring.PageRank;
+import org.lab41.dendrite.jobs.AbstractGraphUpdateJob;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.MetaGraph;
+
+public class PageRankJob extends AbstractGraphUpdateJob {
+
+    private static String PAGERANK_KEY = "jungPagerank";
+    private double alpha;
+
+    public PageRankJob(MetaGraph metaGraph, String jobId, DendriteGraph graph, double alpha) {
+        super(metaGraph, jobId, graph);
+
+        this.alpha = alpha;
+    }
+
+    @Override
+    protected void updateGraph() {
+        GraphJung<DendriteGraph> jungGraph = new GraphJung<>(graph);
+        PageRank<Vertex, Edge> pageRank = new PageRank<>(jungGraph, alpha);
+        pageRank.evaluate();
+
+        for (Vertex vertex: graph.getVertices()) {
+            Double score = pageRank.getVertexScore(vertex);
+            vertex.setProperty(PAGERANK_KEY, score);
+        }
+    }
+
+    @Override
+    protected void createIndices() {
+        createVertexIndex(PAGERANK_KEY, FullDouble.class);
+    }
+}

--- a/src/main/java/org/lab41/dendrite/jobs/titan/DegreeCentralityJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/titan/DegreeCentralityJob.java
@@ -1,0 +1,46 @@
+package org.lab41.dendrite.jobs.titan;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import org.lab41.dendrite.jobs.AbstractGraphUpdateJob;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.MetaGraph;
+
+public class DegreeCentralityJob extends AbstractGraphUpdateJob {
+
+    private static String IN_DEGREES_KEY = "titanInDegrees";
+    private static String OUT_DEGREES_KEY = "titanOutDegrees";
+    private static String DEGREES_KEY = "titanDegrees";
+
+    public DegreeCentralityJob(MetaGraph metaGraph, String jobId, DendriteGraph graph) {
+        super(metaGraph, jobId, graph);
+    }
+
+    @Override
+    protected void updateGraph() {
+        for (Vertex vertex: graph.getVertices()) {
+            int inDegrees = 0;
+            int outDegrees = 0;
+
+            for (Edge ignored : vertex.getEdges(Direction.IN)) {
+                inDegrees += 1;
+            }
+
+            for (Edge ignored : vertex.getEdges(Direction.OUT)) {
+                outDegrees += 1;
+            }
+
+            vertex.setProperty(IN_DEGREES_KEY, inDegrees);
+            vertex.setProperty(OUT_DEGREES_KEY, outDegrees);
+            vertex.setProperty(DEGREES_KEY, inDegrees + outDegrees);
+        }
+    }
+
+    @Override
+    protected void createIndices() {
+        createVertexIndex(IN_DEGREES_KEY, Integer.class);
+        createVertexIndex(OUT_DEGREES_KEY, Integer.class);
+        createVertexIndex(DEGREES_KEY, Integer.class);
+    }
+}

--- a/src/main/java/org/lab41/dendrite/metagraph/DendriteGraphBatchWrapper.java
+++ b/src/main/java/org/lab41/dendrite/metagraph/DendriteGraphBatchWrapper.java
@@ -1,0 +1,177 @@
+package org.lab41.dendrite.metagraph;
+
+import com.thinkaurelius.titan.core.*;
+import com.tinkerpop.blueprints.*;
+import com.tinkerpop.blueprints.Parameter;
+import org.lab41.dendrite.metagraph.DendriteGraph;
+import org.lab41.dendrite.metagraph.DendriteGraphTransactionBuilder;
+import org.lab41.dendrite.metagraph.DendriteGraphTx;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class DendriteGraphBatchWrapper implements TitanGraph {
+
+    DendriteGraph graph;
+
+    public DendriteGraphBatchWrapper(DendriteGraph graph) {
+        this.graph = graph;
+    }
+
+    @Override
+    public void commit() {
+        graph.commit();
+    }
+
+    @Override
+    public void rollback() {
+        graph.rollback();
+    }
+
+    @Override
+    @Deprecated
+    public void stopTransaction(Conclusion conclusion) {
+        graph.stopTransaction(conclusion);
+    }
+
+    public TitanTransaction getCurrentThreadTx() {
+        return graph.getCurrentThreadTx();
+    }
+
+    @Override
+    public String toString() {
+        return graph.toString();
+    }
+
+    @Override
+    public <T extends TitanType> Iterable<T> getTypes(Class<T> clazz) {
+        return graph.getTypes(clazz);
+    }
+
+    @Override
+    public <T extends Element> void dropKeyIndex(String key, Class<T> elementClass) {
+        graph.dropKeyIndex(key, elementClass);
+    }
+
+    @Override
+    public <T extends Element> void createKeyIndex(String key, Class<T> elementClass, Parameter... indexParameters) {
+        graph.createKeyIndex(key, elementClass, indexParameters);
+    }
+
+    @Override
+    public <T extends Element> Set<String> getIndexedKeys(Class<T> elementClass) {
+        return graph.getIndexedKeys(elementClass);
+    }
+
+    @Override
+    public Features getFeatures() {
+        Features features = graph.getFeatures().copyFeatures();
+        features.ignoresSuppliedIds = false;
+        return features;
+    }
+
+    @Override
+    public TitanVertex addVertex(Object id) {
+        return graph.addVertex(id);
+    }
+
+    @Override
+    public TitanVertex getVertex(Object id) {
+        return graph.getVertex(id);
+    }
+
+    @Override
+    public void removeVertex(Vertex vertex) {
+        graph.removeVertex(vertex);
+    }
+
+    @Override
+    public Iterable<Vertex> getVertices() {
+        return graph.getVertices();
+    }
+
+    @Override
+    public DendriteGraphTx newTransaction() {
+        return graph.newTransaction();
+    }
+
+    @Override
+    public DendriteGraphTransactionBuilder buildTransaction() {
+        return graph.buildTransaction();
+    }
+
+    @Override
+    public void shutdown() throws TitanException {
+        graph.shutdown();
+    }
+
+    @Override
+    public KeyMaker makeKey(String name) {
+        return graph.makeKey(name);
+    }
+
+    @Override
+    public LabelMaker makeLabel(String name) {
+        return graph.makeLabel(name);
+    }
+
+    @Override
+    public TitanGraphQuery query() {
+        return graph.query();
+    }
+
+    @Override
+    public TitanIndexQuery indexQuery(String indexName, String query) {
+        return graph.indexQuery(indexName, query);
+    }
+
+    @Override
+    public TitanMultiVertexQuery multiQuery(TitanVertex... vertices) {
+        return graph.multiQuery(vertices);
+    }
+
+    @Override
+    public TitanMultiVertexQuery multiQuery(Collection<TitanVertex> vertices) {
+        return graph.multiQuery(vertices);
+    }
+
+    @Override
+    public TitanType getType(String name) {
+        return graph.getType(name);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return graph.isOpen();
+    }
+
+    @Override
+    public Iterable<Vertex> getVertices(String key, Object value) {
+        return graph.getVertices(key, value);
+    }
+
+    @Override
+    public TitanEdge addEdge(Object id, Vertex outVertex, Vertex inVertex, String label) {
+        return graph.addEdge(id, outVertex, inVertex, label);
+    }
+
+    @Override
+    public TitanEdge getEdge(Object id) {
+        return graph.getEdge(id);
+    }
+
+    @Override
+    public void removeEdge(Edge edge) {
+        graph.removeEdge(edge);
+    }
+
+    @Override
+    public Iterable<Edge> getEdges() {
+        return graph.getEdges();
+    }
+
+    @Override
+    public Iterable<Edge> getEdges(String key, Object value) {
+        return graph.getEdges(key, value);
+    }
+}

--- a/src/main/java/org/lab41/dendrite/metagraph/MetaGraph.java
+++ b/src/main/java/org/lab41/dendrite/metagraph/MetaGraph.java
@@ -41,6 +41,7 @@ public class MetaGraph {
         Properties systemProperties = new Properties();
         loadGraphProperties(systemGraphName, config.subset("metagraph.system"), systemProperties);
 
+        logger.debug("loading system graph");
         this.systemGraph = new DendriteGraph(systemGraphName, systemProperties);
 
         // Create a FramedGraphFactory, which we'll use to wrap our metadata graph vertices and edges.
@@ -56,6 +57,19 @@ public class MetaGraph {
         );
 
         createMetadataGraphKeys();
+    }
+
+    public Set<String> getGraphNames() {
+        Set<String> graphNames = new TreeSet<>();
+
+        MetaGraphTx tx = newTransaction();
+        for (GraphMetadata graphMetadata: tx.getGraphs()) {
+            graphNames.add(graphMetadata.getId());
+        }
+
+        tx.commit();
+
+        return graphNames;
     }
 
     /**
@@ -333,6 +347,8 @@ public class MetaGraph {
 
         DendriteGraph graph = graphs.get(id);
         if (graph == null) {
+            logger.debug("Loading graph " + id);
+
             // Create a default config if we were passed a null config.
             if (properties == null) {
                 properties = getGraphProperties(id);

--- a/src/main/java/org/lab41/dendrite/rexster/DendriteRexsterApplication.java
+++ b/src/main/java/org/lab41/dendrite/rexster/DendriteRexsterApplication.java
@@ -81,13 +81,8 @@ public class DendriteRexsterApplication implements RexsterApplication {
 
     @Override
     public Set<String> getGraphNames() {
-        Set<String> graphNames = new HashSet<>();
+        return metaGraphService.getGraphNames();
 
-        for (DendriteGraph graph: metaGraphService.getGraphs()) {
-            graphNames.add(graph.getId());
-        }
-
-        return graphNames;
     }
 
     @Override

--- a/src/main/java/org/lab41/dendrite/services/MetaGraphService.java
+++ b/src/main/java/org/lab41/dendrite/services/MetaGraphService.java
@@ -17,6 +17,9 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
 
 @Service
 public class MetaGraphService {
@@ -36,6 +39,10 @@ public class MetaGraphService {
 
     public MetaGraph getMetaGraph() {
         return metaGraph;
+    }
+
+    public Set<String> getGraphNames() {
+        return metaGraph.getGraphNames();
     }
 
     public Collection<DendriteGraph> getGraphs() {

--- a/src/main/java/org/lab41/dendrite/services/analysis/jung/BarycenterDistanceService.java
+++ b/src/main/java/org/lab41/dendrite/services/analysis/jung/BarycenterDistanceService.java
@@ -1,17 +1,12 @@
 package org.lab41.dendrite.services.analysis.jung;
 
-import com.thinkaurelius.titan.core.TitanTransaction;
-import com.thinkaurelius.titan.core.attribute.FullDouble;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.oupls.jung.GraphJung;
-import edu.uci.ics.jung.algorithms.scoring.BarycenterScorer;
-import edu.uci.ics.jung.graph.Hypergraph;
+import org.lab41.dendrite.jobs.jung.BarycenterDistanceJob;
 import org.lab41.dendrite.metagraph.DendriteGraph;
-import org.lab41.dendrite.metagraph.models.JobMetadata;
+import org.lab41.dendrite.services.MetaGraphService;
 import org.lab41.dendrite.services.analysis.AnalysisService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -20,57 +15,16 @@ public class BarycenterDistanceService extends AnalysisService {
 
     Logger logger = LoggerFactory.getLogger(BarycenterDistanceService.class);
 
+    @Autowired
+    MetaGraphService metaGraphService;
+
     @Async
-    public void jungBarycenterDistance(DendriteGraph graph, String jobId) {
+    public void run(DendriteGraph graph, String jobId) {
+        BarycenterDistanceJob job = new BarycenterDistanceJob(
+                metaGraphService.getMetaGraph(),
+                jobId,
+                graph);
 
-        logger.debug("Starting analysis on "
-                + graph.getId()
-                + " job " + jobId
-                + " " + Thread.currentThread().getName());
-
-        setJobName(jobId, "jungBarycenterDistance");
-        setJobState(jobId, JobMetadata.RUNNING);
-
-        try {
-            createIndices(graph);
-
-            TitanTransaction tx = graph.newTransaction();
-
-            try {
-                Hypergraph<Vertex, Edge> jungGraph = new GraphJung<>(tx);
-                BarycenterScorer<Vertex, Edge> pageRank = new BarycenterScorer<>(jungGraph);
-
-                for (Vertex vertex: jungGraph.getVertices()) {
-                    Double score = pageRank.getVertexScore(vertex);
-                    vertex.setProperty("jungBarycenterDistance", score);
-                }
-            } catch (Throwable t) {
-                tx.rollback();
-                throw t;
-            }
-
-            tx.commit();
-        } catch (Throwable t) {
-            logger.error("Error:", t);
-            setJobState(jobId, JobMetadata.ERROR, t.getMessage());
-            throw t;
-        }
-
-        setJobState(jobId, JobMetadata.DONE);
-
-        logger.debug("finished job: " + jobId);
-    }
-
-    private void createIndices(DendriteGraph graph) {
-        TitanTransaction tx = graph.newTransaction();
-
-        if (tx.getType("jungBarycenterDistance") == null) {
-            tx.makeKey("jungBarycenterDistance")
-                    .dataType(FullDouble.class)
-                    .indexed(DendriteGraph.INDEX_NAME, Vertex.class)
-                    .make();
-        }
-
-        tx.commit();
+        job.run();
     }
 }

--- a/src/main/java/org/lab41/dendrite/services/analysis/jung/BetweennessCentralityService.java
+++ b/src/main/java/org/lab41/dendrite/services/analysis/jung/BetweennessCentralityService.java
@@ -1,17 +1,12 @@
 package org.lab41.dendrite.services.analysis.jung;
 
-import com.thinkaurelius.titan.core.TitanTransaction;
-import com.thinkaurelius.titan.core.attribute.FullDouble;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.oupls.jung.GraphJung;
-import edu.uci.ics.jung.algorithms.importance.BetweennessCentrality;
-import edu.uci.ics.jung.graph.Graph;
+import org.lab41.dendrite.jobs.jung.BetweennessCentralityJob;
 import org.lab41.dendrite.metagraph.DendriteGraph;
-import org.lab41.dendrite.metagraph.models.JobMetadata;
+import org.lab41.dendrite.services.MetaGraphService;
 import org.lab41.dendrite.services.analysis.AnalysisService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -20,66 +15,16 @@ public class BetweennessCentralityService extends AnalysisService {
 
     Logger logger = LoggerFactory.getLogger(BetweennessCentralityService.class);
 
+    @Autowired
+    MetaGraphService metaGraphService;
+
     @Async
-    public void jungBetweennessCentrality(DendriteGraph graph, String jobId) {
+    public void run(DendriteGraph graph, String jobId) {
+        BetweennessCentralityJob job = new BetweennessCentralityJob(
+                metaGraphService.getMetaGraph(),
+                jobId,
+                graph);
 
-        logger.debug("Starting analysis on "
-                + graph.getId()
-                + " job " + jobId
-                + " " + Thread.currentThread().getName());
-
-        setJobName(jobId, "jungBetweennessCentrality");
-        setJobState(jobId, JobMetadata.RUNNING);
-
-        try {
-            createIndices(graph);
-
-            TitanTransaction tx = graph.newTransaction();
-
-            try {
-                Graph<Vertex, Edge> jungGraph = new GraphJung<>(tx);
-                BetweennessCentrality<Vertex, Edge> betweennessCentrality = new BetweennessCentrality<>(jungGraph);
-                // Instructs the ranker that it should not remove the rank scores from
-                //  the nodes (or edges) once the ranks have been computed.
-                betweennessCentrality.setRemoveRankScoresOnFinalize(false);
-
-                // Performs the iterative process. Note: this method does not return
-                // anything because Java does not allow mixing double, int, or objects
-                // TODO: change this to step() so that insight into the process can be
-                // exposed
-                betweennessCentrality.evaluate();
-
-                for (Vertex vertex: jungGraph.getVertices()) {
-                    Double score = betweennessCentrality.getVertexRankScore(vertex);
-                    vertex.setProperty("jungBetweennessCentrality", score);
-                }
-            } catch (Throwable t) {
-                tx.rollback();
-                throw t;
-            }
-
-            tx.commit();
-        } catch (Throwable t) {
-            logger.error("failed", t);
-            setJobState(jobId, JobMetadata.ERROR, t.getMessage());
-            throw t;
-        }
-
-        setJobState(jobId, JobMetadata.DONE);
-
-        logger.debug("finished job: " + jobId);
-    }
-
-    private void createIndices(DendriteGraph graph) {
-        TitanTransaction tx = graph.newTransaction();
-
-        if (tx.getType("jungBetweennessCentrality") == null) {
-            tx.makeKey("jungBetweennessCentrality")
-                    .dataType(FullDouble.class)
-                    .indexed(DendriteGraph.INDEX_NAME, Vertex.class)
-                    .make();
-        }
-
-        tx.commit();
+        job.run();
     }
 }

--- a/src/main/java/org/lab41/dendrite/services/analysis/jung/ClosenessCentralityService.java
+++ b/src/main/java/org/lab41/dendrite/services/analysis/jung/ClosenessCentralityService.java
@@ -1,17 +1,12 @@
 package org.lab41.dendrite.services.analysis.jung;
 
-import com.thinkaurelius.titan.core.TitanTransaction;
-import com.thinkaurelius.titan.core.attribute.FullDouble;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.oupls.jung.GraphJung;
-import edu.uci.ics.jung.algorithms.scoring.ClosenessCentrality;
-import edu.uci.ics.jung.graph.Graph;
+import org.lab41.dendrite.jobs.jung.ClosenessCentralityJob;
 import org.lab41.dendrite.metagraph.DendriteGraph;
-import org.lab41.dendrite.metagraph.models.JobMetadata;
+import org.lab41.dendrite.services.MetaGraphService;
 import org.lab41.dendrite.services.analysis.AnalysisService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -20,57 +15,16 @@ public class ClosenessCentralityService extends AnalysisService {
 
     Logger logger = LoggerFactory.getLogger(ClosenessCentralityService.class);
 
+    @Autowired
+    MetaGraphService metaGraphService;
+
     @Async
-    public void jungClosenessCentrality(DendriteGraph graph, String jobId) {
+    public void run(DendriteGraph graph, String jobId) {
+        ClosenessCentralityJob job = new ClosenessCentralityJob(
+                metaGraphService.getMetaGraph(),
+                jobId,
+                graph);
 
-        logger.debug("Starting analysis on "
-                + graph.getId()
-                + " job " + jobId
-                + " " + Thread.currentThread().getName());
-
-        setJobName(jobId, "jungClosenessCentrality");
-        setJobState(jobId, JobMetadata.RUNNING);
-
-        try {
-            createIndices(graph);
-
-            TitanTransaction tx = graph.newTransaction();
-
-            try {
-                Graph<Vertex, Edge> jungGraph = new GraphJung<>(tx);
-                ClosenessCentrality<Vertex, Edge> closenessCentrality = new ClosenessCentrality<>(jungGraph);
-
-                for (Vertex vertex: jungGraph.getVertices()) {
-                    Double score = closenessCentrality.getVertexScore(vertex);
-                    vertex.setProperty("jungClosenessCentrality", score);
-                }
-            } catch (Throwable t) {
-                tx.rollback();
-                throw t;
-            }
-
-            tx.commit();
-        } catch (Throwable t) {
-            logger.error("failed", t);
-            setJobState(jobId, JobMetadata.ERROR, t.getMessage());
-            throw t;
-        }
-
-        setJobState(jobId, JobMetadata.DONE);
-
-        logger.debug("Finished analysis job: " + jobId);
-    }
-
-    private void createIndices(DendriteGraph graph) {
-        TitanTransaction tx = graph.newTransaction();
-
-        if (tx.getType("jungClosenessCentrality") == null) {
-            tx.makeKey("jungClosenessCentrality")
-                    .dataType(FullDouble.class)
-                    .indexed(DendriteGraph.INDEX_NAME, Vertex.class)
-                    .make();
-        }
-
-        tx.commit();
+        job.run();
     }
 }

--- a/src/main/java/org/lab41/dendrite/services/analysis/jung/EigenvectorCentralityService.java
+++ b/src/main/java/org/lab41/dendrite/services/analysis/jung/EigenvectorCentralityService.java
@@ -1,17 +1,12 @@
 package org.lab41.dendrite.services.analysis.jung;
 
-import com.thinkaurelius.titan.core.TitanTransaction;
-import com.thinkaurelius.titan.core.attribute.FullDouble;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.oupls.jung.GraphJung;
-import edu.uci.ics.jung.algorithms.scoring.EigenvectorCentrality;
-import edu.uci.ics.jung.graph.Graph;
+import org.lab41.dendrite.jobs.jung.EigenvectorCentralityJob;
 import org.lab41.dendrite.metagraph.DendriteGraph;
-import org.lab41.dendrite.metagraph.models.JobMetadata;
+import org.lab41.dendrite.services.MetaGraphService;
 import org.lab41.dendrite.services.analysis.AnalysisService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -20,60 +15,16 @@ public class EigenvectorCentralityService extends AnalysisService {
 
     Logger logger = LoggerFactory.getLogger(EigenvectorCentralityService.class);
 
+    @Autowired
+    MetaGraphService metaGraphService;
+
     @Async
-    public void jungEigenvectorCentrality(DendriteGraph graph, String jobId) {
+    public void run(DendriteGraph graph, String jobId) {
+        EigenvectorCentralityJob job = new EigenvectorCentralityJob(
+                metaGraphService.getMetaGraph(),
+                jobId,
+                graph);
 
-        logger.debug("Starting analysis on "
-                + graph.getId()
-                + " job " + jobId
-                + " " + Thread.currentThread().getName());
-
-        setJobName(jobId, "jungEigenvectorCentrality");
-        setJobState(jobId, JobMetadata.RUNNING);
-
-        try {
-            createIndices(graph);
-
-            TitanTransaction tx = graph.newTransaction();
-
-            try {
-                Graph<Vertex, Edge> jungGraph = new GraphJung<>(tx);
-                EigenvectorCentrality<Vertex, Edge> eigenvectorCentrality = new EigenvectorCentrality<>(jungGraph);
-                eigenvectorCentrality.acceptDisconnectedGraph(true);
-                eigenvectorCentrality.evaluate();
-
-                for (Vertex vertex: jungGraph.getVertices()) {
-                    Double score = eigenvectorCentrality.getVertexScore(vertex);
-                    vertex.setProperty("jungEigenvectorCentrality", score);
-                }
-            } catch (Throwable t) {
-                tx.rollback();
-                throw t;
-            }
-
-            tx.commit();
-        } catch (Throwable t) {
-            logger.debug("Error:", t);
-            setJobState(jobId, JobMetadata.ERROR, t.getMessage());
-            throw t;
-        }
-
-        setJobState(jobId, JobMetadata.DONE);
-
-        logger.debug("Finished analysis job: " + jobId);
+        job.run();
     }
-
-    private void createIndices(DendriteGraph graph) {
-        TitanTransaction tx = graph.newTransaction();
-
-        if (tx.getType("jungEigenvectorCentrality") == null) {
-            tx.makeKey("jungEigenvectorCentrality")
-                    .dataType(FullDouble.class)
-                    .indexed(DendriteGraph.INDEX_NAME, Vertex.class)
-                    .make();
-        }
-
-        tx.commit();
-    }
-
 }

--- a/src/main/java/org/lab41/dendrite/services/analysis/jung/PageRankService.java
+++ b/src/main/java/org/lab41/dendrite/services/analysis/jung/PageRankService.java
@@ -1,17 +1,12 @@
 package org.lab41.dendrite.services.analysis.jung;
 
-import com.thinkaurelius.titan.core.TitanTransaction;
-import com.thinkaurelius.titan.core.attribute.FullDouble;
-import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.oupls.jung.GraphJung;
-import edu.uci.ics.jung.algorithms.scoring.PageRank;
-import edu.uci.ics.jung.graph.Hypergraph;
+import org.lab41.dendrite.jobs.jung.PageRankJob;
 import org.lab41.dendrite.metagraph.DendriteGraph;
-import org.lab41.dendrite.metagraph.models.JobMetadata;
+import org.lab41.dendrite.services.MetaGraphService;
 import org.lab41.dendrite.services.analysis.AnalysisService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -20,57 +15,17 @@ public class PageRankService extends AnalysisService {
 
     Logger logger = LoggerFactory.getLogger(PageRankService.class);
 
+    @Autowired
+    MetaGraphService metaGraphService;
+
     @Async
-    public void jungPageRank(DendriteGraph graph, String jobId, double alpha) {
+    public void run(DendriteGraph graph, String jobId, double alpha) {
+        PageRankJob job = new PageRankJob(
+                metaGraphService.getMetaGraph(),
+                jobId,
+                graph,
+                alpha);
 
-        logger.debug("Starting analysis on "
-                + graph.getId()
-                + " job " + jobId
-                + " " + Thread.currentThread().getName());
-
-        setJobName(jobId, "jungPageRank");
-        setJobState(jobId, JobMetadata.RUNNING);
-
-        try {
-            createIndices(graph);
-
-            TitanTransaction tx = graph.newTransaction();
-            try {
-                Hypergraph<Vertex, Edge> jungGraph = new GraphJung<>(tx);
-                PageRank<Vertex, Edge> pageRank = new PageRank<>(jungGraph, alpha);
-                pageRank.evaluate();
-
-                for (Vertex vertex: jungGraph.getVertices()) {
-                    Double score = pageRank.getVertexScore(vertex);
-                    vertex.setProperty("jungPageRank", score);
-                }
-            } catch (Throwable t) {
-                tx.rollback();
-                throw t;
-            }
-
-            tx.commit();
-        } catch (Throwable t) {
-            logger.error("failed", t);
-            setJobState(jobId, JobMetadata.ERROR, t.getMessage());
-            throw t;
-        }
-
-        setJobState(jobId, JobMetadata.DONE);
-
-        logger.debug("finished job: " + jobId);
-    }
-
-    private void createIndices(DendriteGraph graph) {
-        TitanTransaction tx = graph.newTransaction();
-
-        if (tx.getType("jungPageRank") == null) {
-            tx.makeKey("jungPageRank")
-                    .dataType(FullDouble.class)
-                    .indexed(DendriteGraph.INDEX_NAME, Vertex.class)
-                    .make();
-        }
-
-        tx.commit();
+        job.run();
     }
 }

--- a/src/main/java/org/lab41/dendrite/web/controller/analysis/JungController.java
+++ b/src/main/java/org/lab41/dendrite/web/controller/analysis/JungController.java
@@ -82,7 +82,7 @@ public class JungController {
         tx.commit();
 
         // We can't pass the values directly because they'll live in a separate thread.
-        barycenterDistanceService.jungBarycenterDistance(graph, jobMetadata.getId());
+        barycenterDistanceService.run(graph, jobMetadata.getId());
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -127,7 +127,7 @@ public class JungController {
         tx.commit();
 
         // We can't pass the values directly because they'll live in a separate thread.
-        betweennessCentralityService.jungBetweennessCentrality(graph, jobMetadata.getId());
+        betweennessCentralityService.run(graph, jobMetadata.getId());
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -171,7 +171,7 @@ public class JungController {
         tx.commit();
 
         // We can't pass the values directly because they'll live in a separate thread.
-        closenessCentralityService.jungClosenessCentrality(graph, jobMetadata.getId());
+        closenessCentralityService.run(graph, jobMetadata.getId());
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -215,7 +215,7 @@ public class JungController {
         tx.commit();
 
         // We can't pass the values directly because they'll live in a separate thread.
-        eigenvectorCentralityService.jungEigenvectorCentrality(graph, jobMetadata.getId());
+        eigenvectorCentralityService.run(graph, jobMetadata.getId());
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -267,7 +267,7 @@ public class JungController {
         tx.commit();
 
         // We can't pass the values directly because they'll live in a separate thread.
-        pageRankService.jungPageRank(graph, jobMetadata.getId(), item.getAlpha());
+        pageRankService.run(graph, jobMetadata.getId(), item.getAlpha());
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }


### PR DESCRIPTION
There was a lot of copy-pasting going on in the jung analysis services. This abstracts out the common code and provides a nicer interface for jobs that annotate every vertex with a piece of information.

Also, this fixes a performance bug where the project dropdown ended up forcing a connection for every graph.
