### PR TITLE
fixed git clone url in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ Dendrite is a Lab41 exploration of ways to analyze, manipulate, version, and sha
 <li>
 <p>Check out the code:</p>
 
-<pre><code>% git clone https://github.com/Lab4/Dendrite.git
+<pre><code>% git clone https://github.com/Lab41/Dendrite.git
 % cd Dendrite
 </code></pre>
 </li>


### PR DESCRIPTION
The git clone url shown in the install instructions on the website (http://lab41.github.io/Dendrite/) is wrong.

```
% git clone https://github.com/Lab4/Dendrite.git
```

should be:

```
% git clone https://github.com/Lab41/Dendrite.git
```
