### PR TITLE
Add a dependency on spring-security-ldap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,11 @@
             <artifactId>spring-security-config</artifactId>
             <version>${spring-security.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-ldap</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
 
         <!-- Jersey Dependency for Spring-->
         <dependency>


### PR DESCRIPTION
This lets users hook dendrite into ldap without needing to recompile the WAR.
