### PR TITLE
Fix subgraph carving using bad _ids

### DIFF
--- a/src/main/java/org/lab41/dendrite/jobs/BranchCommitSubsetJob.java
+++ b/src/main/java/org/lab41/dendrite/jobs/BranchCommitSubsetJob.java
@@ -91,8 +91,7 @@ public class BranchCommitSubsetJob extends AbstractGraphCommitJob {
                 .setQuery(queryBuilder)
                 .setSize(SIZE)
                 .setSearchType(SearchType.SCAN)
-                .setScroll(new TimeValue(60000))
-                .addField("_vertexId");
+                .setScroll(new TimeValue(60000));
 
         TitanTransaction srcTx = srcGraph.newTransaction();
 
@@ -101,7 +100,7 @@ public class BranchCommitSubsetJob extends AbstractGraphCommitJob {
 
             try {
                 for (SearchHit hit: scan(srcGraph.getElasticSearchClient(), srb)) {
-                    Vertex vertex = srcTx.getVertex(hit.field("_vertexId").value());
+                    Vertex vertex = srcTx.getVertex(hit.getId());
                     copyVertex(srcTx, dstTx, vertex, 0);
                 }
             } catch (Exception e) {
@@ -167,7 +166,9 @@ public class BranchCommitSubsetJob extends AbstractGraphCommitJob {
 
     private void copyProperties(Element src, Element dst) {
         for (String key: src.getPropertyKeys()) {
-            dst.setProperty(key, src.getProperty(key));
+            if (!key.equals("_id")) {
+                dst.setProperty(key, src.getProperty(key));
+            }
         }
     }
 

--- a/src/main/java/org/lab41/dendrite/metagraph/DendriteGraph.java
+++ b/src/main/java/org/lab41/dendrite/metagraph/DendriteGraph.java
@@ -24,7 +24,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class DendriteGraph extends TitanBlueprintsGraph {
 
     public static final String INDEX_NAME = "search";
-    public static final String VERTEX_ID_KEY = "_vertexId";
+    public static final String VERTEX_ID_KEY = "_id";
 
     private Logger logger = LoggerFactory.getLogger(DendriteGraph.class);
 

--- a/src/main/webapp/js/controllers.js
+++ b/src/main/webapp/js/controllers.js
@@ -766,12 +766,12 @@ angular.module('dendrite.controllers', []).
                 var resultKeys = {};
                 data.hits.hits.forEach(function(hit) {
                   if (hit._type === $scope.objectType) {
-                    hit._source._id = hit._source._vertexId;
+                    hit._source._id = hit._source._id;
                     resultArray.push(hit._source);
 
                     // extract all keys (to dynamically update table columns)
                     Object.keys(hit._source).forEach(function(k) {
-                      if (k !== ($scope.objectType+'Id') && k !== "_id" && k !== "_vertexId") {
+                      if (k !== ($scope.objectType+'Id') && k !== "_id") {
                         resultKeys[k] = true;
                       }
                     });


### PR DESCRIPTION
We weren't updating the "_vertexId" when copying graphs, which really
confused how subgraph carving happens. Since we our fork of titan-es
preserves _ids between Titan and ES, we can just use ES's "_id" field
and get rid of "_vertexId".
