### PR TITLE
Disable running branch commits in the background

### DIFF
--- a/src/main/java/org/lab41/dendrite/web/controller/BranchController.java
+++ b/src/main/java/org/lab41/dendrite/web/controller/BranchController.java
@@ -263,7 +263,8 @@ public class BranchController {
                 jobMetadata.getId(),
                 branchMetadata.getId());
 
-        taskExecutor.execute(branchCommitJob);
+        //taskExecutor.execute(branchCommitJob);
+        branchCommitJob.run();
 
         response.put("status", "ok");
         response.put("msg", "job submitted");
@@ -405,7 +406,8 @@ public class BranchController {
                 jobMetadata.getId(),
                 branchMetadata.getId());
 
-        taskExecutor.execute(branchCommitJob);
+        //taskExecutor.execute(branchCommitJob);
+        branchCommitJob.run();
 
         response.put("status", "ok");
         response.put("msg", "job submitted");
@@ -504,7 +506,8 @@ public class BranchController {
                 query,
                 steps);
 
-        taskExecutor.execute(branchCommitSubsetJob);
+        //taskExecutor.execute(branchCommitSubsetJob);
+        branchCommitSubsetJob.run();
 
         response.put("status", "ok");
         response.put("msg", "job submitted");
@@ -573,7 +576,8 @@ public class BranchController {
                 query,
                 steps);
 
-        taskExecutor.execute(branchCommitSubsetJob);
+        //taskExecutor.execute(branchCommitSubsetJob);
+        branchCommitSubsetJob.run();
 
         response.put("status", "ok");
         response.put("msg", "job submitted");


### PR DESCRIPTION
The UI is not yet polling on the job status of branch creation. So in the meantime, we'll just run it synchronously.
