### PR TITLE
synchronously load the project graphs

### DIFF
--- a/src/main/java/org/lab41/dendrite/web/controller/GraphController.java
+++ b/src/main/java/org/lab41/dendrite/web/controller/GraphController.java
@@ -66,6 +66,9 @@ public class GraphController {
             return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
         }
 
+        // FIXME: Temporary hack to force loading the graph until the UI can handle it occurring asynchronously.
+        metaGraphService.getGraph(graphMetadata.getId());
+
         response.put("graph", getGraphMap(graphMetadata));
 
         // Commit must come after all graph access.
@@ -257,6 +260,10 @@ public class GraphController {
         }
 
         GraphMetadata graphMetadata = projectMetadata.getCurrentGraph();
+
+        // FIXME: Temporary hack to force loading the graph until the UI can handle it occurring asynchronously.
+        metaGraphService.getGraph(graphMetadata.getId());
+
         response.put("graph", getGraphMap(graphMetadata));
 
         // Commit must come after all graph access.

--- a/src/main/java/org/lab41/dendrite/web/controller/ProjectController.java
+++ b/src/main/java/org/lab41/dendrite/web/controller/ProjectController.java
@@ -63,6 +63,9 @@ public class ProjectController {
             return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
         }
 
+        // FIXME: Temporary hack to force loading the graph until the UI can handle it occurring asynchronously.
+        metaGraphService.getGraph(projectMetadata.getCurrentGraph().getId());
+
         response.put("project", getProjectMap(projectMetadata));
 
         // Commit must come after all graph access.


### PR DESCRIPTION
This is a temporary workaround until the UI handles loading the graphs asynchronously.
