### PR TITLE
Make sure when we create a git repo we make an initial commit

### DIFF
--- a/src/main/java/org/lab41/dendrite/services/HistoryService.java
+++ b/src/main/java/org/lab41/dendrite/services/HistoryService.java
@@ -58,6 +58,11 @@ public class HistoryService {
                     .setDirectory(gitDir)
                     .setBare(false)
                     .call();
+
+            git.commit()
+                    .setAuthor("", "")
+                    .setMessage("commit")
+                    .call();
         }
 
         return git;


### PR DESCRIPTION
This lets us create a branch without creating an initial commit
